### PR TITLE
Update package settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,21 +12,10 @@
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-/*
- * build.gradle.kts
- * Copyright (C) 2022 Hyperspace Developers.
- * This file is part of project Foxy.
- *
- * The Foxy project is non-violent software: you can use, redistribute, and/or modify it under the terms of the NPLv7+
- * as found in the LICENSE file in the source code root directory or at <https://git.pixie.town/thufie/npl-builder>.
- *
- * The Foxy project comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law.  See the
- * NPL for details.
- */
-
 plugins {
     kotlin("multiplatform") version "1.6.20"
     kotlin("plugin.serialization") version "1.6.20"
+    id("maven-publish")
 }
 
 group = "dev.hyperspace"
@@ -34,6 +23,19 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/hyperspacedev/foxy")
+            credentials {
+                username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
+                password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")
+            }
+        }
+    }
 }
 
 kotlin {
@@ -46,7 +48,7 @@ kotlin {
             useJUnitPlatform()
         }
     }
-    js(BOTH) {
+    js(IR) {
         browser {
             commonWebpackConfig {
                 cssSupport.enabled = true
@@ -74,7 +76,6 @@ kotlin {
             val ktor_version: String by project
             dependencies {
                 implementation("io.ktor:ktor-client-core:$ktor_version")
-                implementation("io.ktor:ktor-client-cio:$ktor_version")
                 implementation("com.goncalossilva:murmurhash:0.4.0")
                 implementation("io.ktor:ktor-client-auth:$ktor_version")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.3.2")
@@ -87,9 +88,20 @@ kotlin {
                 implementation(kotlin("test"))
             }
         }
-        val jvmMain by getting
+        val jvmMain by getting {
+            val ktor_version: String by project
+            dependencies {
+                implementation("io.ktor:ktor-client-cio:$ktor_version")
+            }
+        }
         val jvmTest by getting
-        val jsMain by getting
+        val jsMain by getting {
+            val ktor_version: String by project
+
+            dependencies {
+                implementation("io.ktor:ktor-client-js:$ktor_version")
+            }
+        }
         val jsTest by getting
         val nativeMain by getting
         val nativeTest by getting

--- a/src/commonMain/kotlin/Foxy.kt
+++ b/src/commonMain/kotlin/Foxy.kt
@@ -12,7 +12,6 @@
 
 import io.ktor.client.*
 import io.ktor.client.call.*
-import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -63,7 +62,7 @@ object Foxy {
 
     /** The primary HTTP client agent. */
     @OptIn(ExperimentalSerializationApi::class)
-    private val client = HttpClient(CIO) {
+    private val client = HttpClient {
         install(ContentNegotiation) {
             json(Json {
                 prettyPrint = true


### PR DESCRIPTION
In attempting to test that publishing works, I encountered a few issues pertaining to the JS versions of our library.

- First, MurmurHash and Ktor CIO would not resolve properly. It appears that MurmurHash was only built with only the new JS/IR backend in mind, and not both IR and legacy. I changed the JS target to only build for IR instead because it's unlikely we'd do anything with the legacy backend.
- Second, CIO is only supported on the JVM. I removed the CIO dependency, and it appears that the tests succeed anyway, which leads me to believe we didn't really need CIO in the first place.

There are also some other changes to allow publishing to the GitHub Package Registry.